### PR TITLE
feat: use Set to remove duplicates

### DIFF
--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -37,3 +37,37 @@ Consider using a scope for more grained results.
   ",
 ]
 `;
+
+exports[`kirinus() Removes duplicates from same commit type 1`] = `
+Array [
+  "
+## Changes
+
+### :zap: Features
+
+- \`commit 1\`
+
+### :wrench: Fixes
+
+- \`commit 2\`
+- \`commit 4\`
+
+### :construction_worker: Maintenance
+
+- \`commit 3\`
+
+### :books: Documentation
+
+- \`commit 4\`
+
+### :nail_care: Style
+
+- \`format files\`
+
+## Files
+
+- \`file1.md\`
+- \`file2.js\`
+  ",
+]
+`;

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -236,4 +236,26 @@ describe('kirinus()', () => {
     expect(global.fail).not.toBeCalled();
     expect(global.markdown).toBeCalled();
   });
+
+  it('Removes duplicates from same commit type', async () => {
+    global.danger = {
+      ...danger,
+      github: {
+        ...danger.github,
+        commits: danger.github.commits.concat([
+          { commit: { message: 'style: format files' } },
+          { commit: { message: 'style: format files' } },
+        ]),
+        pr: {
+          ...danger.github.pr,
+        },
+      },
+    };
+
+    await kirinus({ conventional: { severity: Severity.Disable } });
+
+    const content = global.markdown.mock.calls[0][0] as string;
+    expect(content.match(/format files/g)).toHaveLength(1);
+    expect(global.markdown.mock.calls[0]).toMatchSnapshot();
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,7 +247,9 @@ function renderMarkdown({ fileLimit = 50 }: { fileLimit?: number }) {
 ## Changes
 
 ${Object.entries(changesByType)
-  .map(([changeType, messages]) => renderCommitGroupMarkdown(changeType, messages))
+  .map(([changeType, messages]) =>
+    renderCommitGroupMarkdown(changeType, Array.from(new Set(messages)))
+  )
   .join('\n\n')}
 
 ## Files


### PR DESCRIPTION
Remove duplicated messages from the same type of commit.
Example of what we want to avoid

![image](https://user-images.githubusercontent.com/43855513/129040345-b0d2a5ef-e5f0-493c-bac1-7de5b56e86b5.png)
