### PR TITLE
feat: show commit scope if any

### DIFF
--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -11,8 +11,8 @@ Array [
 
 ### :wrench: Fixes
 
-- \`commit 2\`
-- \`commit 4\`
+- \`my-app1: commit 2\`
+- \`my-app: commit 4\`
 
 ### :construction_worker: Maintenance
 
@@ -20,7 +20,7 @@ Array [
 
 ### :books: Documentation
 
-- \`commit 4\`
+- \`my-app2: commit 4\`
 
 ### :question: Uncategorized
 
@@ -49,8 +49,8 @@ Array [
 
 ### :wrench: Fixes
 
-- \`commit 2\`
-- \`commit 4\`
+- \`my-app1: commit 2\`
+- \`my-app: commit 4\`
 
 ### :construction_worker: Maintenance
 
@@ -58,7 +58,7 @@ Array [
 
 ### :books: Documentation
 
-- \`commit 4\`
+- \`my-app2: commit 4\`
 
 ### :nail_care: Style
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,7 +235,7 @@ function renderMarkdown({ fileLimit = 50 }: { fileLimit?: number }) {
   commits.forEach(({ commit: { message } }) => {
     const commitType = getConventionalCommitType(conventionalCommitTypes, message);
     if (commitType !== null && message.includes(':')) {
-      const [, scope, msg] = /\w+(?:\((\S+)?\))?:(.+)/.exec(message) as RegExpExecArray;
+      const [, scope, msg] = /\w+(?:\((.+)?\))?:(.+)/.exec(message) as RegExpExecArray;
       const description = scope ? `${scope}: ${msg.trim()}` : msg.trim();
       changesByType[commitType]
         ? changesByType[commitType].push(description)

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,7 +235,8 @@ function renderMarkdown({ fileLimit = 50 }: { fileLimit?: number }) {
   commits.forEach(({ commit: { message } }) => {
     const commitType = getConventionalCommitType(conventionalCommitTypes, message);
     if (commitType !== null && message.includes(':')) {
-      const description = message.split(':')[1].trim();
+      const [, scope, msg] = /\w+(?:\((\S+)?\))?:(.+)/.exec(message) as RegExpExecArray;
+      const description = scope ? `${scope}: ${msg.trim()}` : msg.trim();
       changesByType[commitType]
         ? changesByType[commitType].push(description)
         : (changesByType[commitType] = [description]);


### PR DESCRIPTION
Show commit scope in PR comment to have a context of the commit. This helps during reviews to give more context/information about each commit.
Alternatively we can format it as `{message} [{scope}]`
E.g.
```
lib-components: added component input
ui-patients: deleted login screen
this commit has no scope
```